### PR TITLE
バックエンドのデータ形式変更に応じてフロントでも受け取り方を変更

### DIFF
--- a/react/src/pages/update-availability/UpdateAvailability.tsx
+++ b/react/src/pages/update-availability/UpdateAvailability.tsx
@@ -9,6 +9,20 @@ type PendingOverlay = {
   end: string;
 };
 
+type ApiScheduleTimeslot = {
+  id: number;
+  start_time: string;
+  end_time: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type ApiScheduleResponse = {
+  uuid: string;
+  title: string;
+  schedule_timeslots: ApiScheduleTimeslot[];
+};
+
 // ====== ダミーデータ ======
 type Timeslot = {
   schedule_uuid: string;
@@ -19,7 +33,7 @@ type Timeslot = {
 type ScheduleApiResponse = {
   uuid: string;
   title: string;
-  timeslots: Timeslot[];
+  schedule_timeslots: ApiScheduleTimeslot[]; // 👈 修正
 };
 
 const DUMMY_SCHEDULE_TIMESLOTS: Timeslot[] = [
@@ -288,7 +302,8 @@ export function UpdateAvailability({scheduleUuid,}: UpdateAvailabilityProps) {
         );
         if (!res.ok) throw new Error("API error: " + res.status);
         const data: ScheduleApiResponse = await res.json();
-        setTimeslots(Array.isArray(data.timeslots) ? data.timeslots : []);
+        console.log("data", data);
+        setTimeslots(data.schedule_timeslots);
       } catch (err) {
         console.error(err);
       } finally {


### PR DESCRIPTION
## 動作確認
- [ ] http://localhost:5173/?schedule-uuid={UUIDを入力} でカレンダーがこれまで通り表示され、新規アベイラビリティ入力もできることを確認

<img width="961" height="750" alt="スクリーンショット 2025-09-13 15 29 45" src="https://github.com/user-attachments/assets/f5a031d9-c6e9-4524-9b87-5df10d65aa8e" />
